### PR TITLE
Feature  - API - add route to get comments by user id

### DIFF
--- a/src/routes/entity.js
+++ b/src/routes/entity.js
@@ -16,6 +16,28 @@ export const getComments = async (req, res) => {
 		.catch((err) => handleErr(err, res));
 };
 
+export const getCommentsByUserId = async (req, res) => {
+	const userId = req?.params.userId;
+	const query = [
+		{
+			$unwind: {
+				path: '$comments'
+			}
+		},
+		{
+			$match: {
+				'comments.userId': userId
+			}
+		}
+	];
+
+	await Comment.aggregate(query)
+		.then((data) => {
+			return res.json({comments: data});
+		})
+		.catch((err) => handleErr(err, res));
+};
+
 export const deleteCommentById = async (req, res) => {
 	const {orgId, serviceId, commentId} = req?.params;
 	const query = getEntityQuery({organizationId: orgId, serviceId: serviceId});

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -14,7 +14,8 @@ import {
 	updateComments,
 	deleteCommentById,
 	updateCommentById,
-	updateRatings
+	updateRatings,
+	getCommentsByUserId
 } from './entity';
 import {
 	approveOrgOwner,
@@ -152,6 +153,7 @@ versionOneRouter.get(
 );
 
 // Comments - Partially Automation tested
+versionOneRouter.get('/comments/:userId', getCommentsByUserId);
 versionOneRouter.get('/organizations/:orgId/comments', getComments);
 versionOneRouter.patch(
 	'/organizations/:orgId/comments',


### PR DESCRIPTION
## Description
adding a route that will get all comments based on a userId
versionOneRouter.get('/comments/:userId', getCommentsByUserId); returns all comments left by a specific user
this route calls getCommentsByUserId which is an aggregation pipeline

## Asana ticket:
https://app.asana.com/0/1132189118126148/1203247962838488

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
