### PR TITLE
Feature - Data - adding lcr interest flag to User Scheme

### DIFF
--- a/src/mongoose.js
+++ b/src/mongoose.js
@@ -274,6 +274,7 @@ const UserSchema = new Schema(
 		orgType: String,
 		reasonForJoining: String,
 		reviewerQuestions: {
+			reviewerInterested: {type: Boolean, default: false},
 			verifyAnswer: {type: Boolean, default: false},
 			timeCommitAnswer: {type: Boolean, default: false},
 			specifiedTimeCommit: String,


### PR DESCRIPTION
## Description
To better support eh Local Community Reviewer Beta program, added a new field to the reviewerQuestions user property called 'reviewerInterested'.

The default value is false 
It will be set to 'true' if a user creates an account as a Local Community User but then answers "No" to the first question related to being an InReach insider.

This PR is related to a catatlog PR here, [https://github.com/weareinreach/inreach-catalog/pull/403](url)

## Asana ticket:

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
